### PR TITLE
複数のPermissionsを指定したときに認証リンクが不正になる問題を修正

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -87,7 +87,7 @@ export class MiAuth {
     const urlParam: Record<string, string> = {
       name: param.name,
       callback: param.callback as string,
-      permission: param.permission.join(", "),
+      permission: param.permission.join(","),
     };
 
     const convertdParam = new URLSearchParams();


### PR DESCRIPTION
MiauthのURLパラメータの`permission`クエリには空白なしのコンマ区切りで渡す必要があるようです。
配列からパラメータにする際にコンマの後ろに空白が入っていたので修正しました。

参考：https://forum.misskey.io/d/6-miauth