### PR TITLE
✨ (auth.ts) Add getToken method as static

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -62,11 +62,19 @@ export class MiAuth {
    * return misskey api token
    * when failed authentication, throw AuthenticationError
    */
-  public async getToken(): Promise<string> {
-    const url = new URL(
-      join("api", "miauth", this.session, "check"),
-      this.origin,
-    );
+  public getToken(): Promise<string> {
+    return MiAuth.getToken(this.origin, this.session);
+  }
+
+  /**
+   * return misskey api token
+   * when failed authentication, throw AuthenticationError
+   */
+  public static async getToken(
+    origin: string,
+    session: string,
+  ): Promise<string> {
+    const url = new URL(join("api", "miauth", session, "check"), origin);
 
     const data: Record<string, unknown> = await ky.post(url).json();
     const token = String(data.token);


### PR DESCRIPTION
For example, when redirecting a website, it is difficult to hold a MiAuth instance. In such cases, some information is stored in cookies or local storage. static getToken allows for token retrieval in such situations with minimal information and without creating a new instance of the MiAuth object.